### PR TITLE
Improvements to /town claim

### DIFF
--- a/SimpleTowns/src/com/gmail/jameshealey1994/simpletowns/commands/command/AddCommand.java
+++ b/SimpleTowns/src/com/gmail/jameshealey1994/simpletowns/commands/command/AddCommand.java
@@ -8,6 +8,8 @@ import com.gmail.jameshealey1994.simpletowns.object.Town;
 import com.gmail.jameshealey1994.simpletowns.permissions.STPermission;
 import com.gmail.jameshealey1994.simpletowns.utils.Logger;
 import com.gmail.jameshealey1994.simpletowns.utils.NameValidityChecker;
+
+import java.util.ArrayList;
 import java.util.List;
 import org.bukkit.Server;
 import org.bukkit.command.CommandSender;
@@ -104,8 +106,14 @@ public class AddCommand extends STCommand {
             return true;
         }
 
-        //Create and call event
-        final TownAddEvent event = new TownAddEvent(town, sender, fullPlayerName);
+        // The messages to be sent to the event
+        List<String> preparedMessages = new ArrayList<>();
+        
+        // The confirmation messages to send to the sender 
+        preparedMessages.add(localisation.get(LocalisationEntry.MSG_CITIZEN_ADDED, town.getName(), fullPlayerName));
+        
+        // Create and call event
+        final TownAddEvent event = new TownAddEvent(town, sender, fullPlayerName, preparedMessages);
         plugin.getServer().getPluginManager().callEvent(event);
 
         // Check event has not been cancelled by event listeners
@@ -128,8 +136,10 @@ public class AddCommand extends STCommand {
         // Save config
         plugin.saveConfig();
 
-        // Send confimation message to sender
-        sender.sendMessage(localisation.get(LocalisationEntry.MSG_CITIZEN_ADDED, town.getName(), fullPlayerName));
+        // Send messages to sender
+        for(String message : preparedMessages) {
+            sender.sendMessage(message);
+        }
 
         // Send message to citizen, if they're online
         final Player citizen = plugin.getServer().getPlayer(fullPlayerName);

--- a/SimpleTowns/src/com/gmail/jameshealey1994/simpletowns/commands/command/ClaimCommand.java
+++ b/SimpleTowns/src/com/gmail/jameshealey1994/simpletowns/commands/command/ClaimCommand.java
@@ -8,8 +8,11 @@ import com.gmail.jameshealey1994.simpletowns.object.Town;
 import com.gmail.jameshealey1994.simpletowns.object.TownChunk;
 import com.gmail.jameshealey1994.simpletowns.permissions.STPermission;
 import com.gmail.jameshealey1994.simpletowns.utils.Logger;
+
+import java.util.ArrayList;
 import java.util.List;
 import org.bukkit.Chunk;
+import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -40,13 +43,88 @@ public class ClaimCommand extends STCommand {
             return true;
         }
 
+        Town decidedTown = null;
+        final Player player = (Player) sender;
+        
         if (args.length == 0) {
-            sender.sendMessage(localisation.get(LocalisationEntry.ERR_SPECIFY_TOWN));
-            return false;
+        	
+        	int countLeaderOf = 0;
+        	Town townLeaderOf = null;
+        	
+        	for(Town checkingTown : plugin.getTowns().values()) {
+        		if(checkingTown.getLeaders().contains(player.getName())) {
+        			countLeaderOf++;
+        			townLeaderOf = checkingTown;
+        		}
+        	}
+        	
+        	if(countLeaderOf == 1) {
+        		decidedTown = townLeaderOf;
+        	} else {
+	        	Location loc = player.getLocation();
+	        	Chunk c = loc.getChunk();
+	        	
+	        	Town townA = plugin.getTown(loc.getWorld().getChunkAt(c.getX()+1, c.getZ()));
+	        	Town townB = plugin.getTown(loc.getWorld().getChunkAt(c.getX()-1, c.getZ()));
+	        	Town townC = plugin.getTown(loc.getWorld().getChunkAt(c.getX(), c.getZ()+1));
+	        	Town townD = plugin.getTown(loc.getWorld().getChunkAt(c.getX(), c.getZ()-1));
+	        	
+	        	List<Town> towns = new ArrayList<Town>();
+	        	
+	        	if(townA != null) { 
+	        		if(townA.getLeaders().contains(sender.getName()) && !towns.contains(townA)) {
+	        			towns.add(townA);
+	        		}
+	        	}
+	        	
+	        	if(townB != null) {
+	        		if(townB.getLeaders().contains(sender.getName()) && !towns.contains(townB)) {
+	        			towns.add(townB);
+	        		}
+	        	}
+	        	
+	        	if(townC != null) {
+	        		if(townC.getLeaders().contains(sender.getName()) && !towns.contains(townC)) {
+	        			towns.add(townC);
+	        		}
+	        	}
+	        	
+	        	if(townD != null) {
+	        		if(townD.getLeaders().contains(sender.getName()) && !towns.contains(townD)) {
+	        			towns.add(townD);
+	        		}
+	        	}
+	        	
+	        	if(towns.size() == 0) {
+	        		sender.sendMessage(localisation.get(LocalisationEntry.ERR_SPECIFY_TOWN));
+	        		
+	        		return false;
+	        	} else if(towns.size() == 1) {
+	        		decidedTown = towns.get(0);
+	        	} else {
+	        		String townList = "";
+	        		
+	        		int i = 0;
+	        		for(Town currentTown : towns) {
+	        			i++;
+	        			if(i == towns.size()) {
+	        				townList += currentTown.getName()+".";
+	        			} else {
+	        				townList += currentTown.getName()+", ";
+	        			}
+	        		}
+	        		
+	        		sender.sendMessage(localisation.get(LocalisationEntry.MSG_MULTIPLE_TOWNS_NEARBY, townList));
+	        		
+	                return true;
+	        	}
+        	}
+        } else {
+        	decidedTown = plugin.getTown(args[0]);
         }
 
-        final Player player = (Player) sender;
-        final Town town = plugin.getTown(args[0]);
+        
+        final Town town = decidedTown;
 
         // Check town exists
         if (town == null) {

--- a/SimpleTowns/src/com/gmail/jameshealey1994/simpletowns/events/TownAddEvent.java
+++ b/SimpleTowns/src/com/gmail/jameshealey1994/simpletowns/events/TownAddEvent.java
@@ -1,5 +1,7 @@
 package com.gmail.jameshealey1994.simpletowns.events;
 
+import java.util.List;
+
 import com.gmail.jameshealey1994.simpletowns.object.Town;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.Cancellable;
@@ -34,12 +36,18 @@ public class TownAddEvent extends Event implements Cancellable {
      * The name of the player about to be added to the town.
      */
     private final String addedName;
-
+    
+    /**
+     * The messages that the plugin will be sending to the executer
+     * of the event.
+     */
+    private List<String> messages;
+    
     /**
      * If the event is cancelled.
      */
     private boolean cancelled = false;
-
+    
     /**
      * Constructor - Sets the member variables.
      *
@@ -47,10 +55,11 @@ public class TownAddEvent extends Event implements Cancellable {
      * @param sender        sender of the command to add the player
      * @param addedName     name of the player about to be added to the town
      */
-    public TownAddEvent(Town town, CommandSender sender, String addedName) {
+    public TownAddEvent(Town town, CommandSender sender, String addedName, List<String> messages) {
         this.town = town;
         this.sender = sender;
         this.addedName = addedName;
+        this.messages = messages;
     }
 
     /**
@@ -88,6 +97,10 @@ public class TownAddEvent extends Event implements Cancellable {
      */
     public String getAddedName() {
         return addedName;
+    }
+    
+    public List<String> getMessages() {
+    	return messages;
     }
 
     @Override

--- a/SimpleTowns/src/com/gmail/jameshealey1994/simpletowns/localisation/LocalisationEntry.java
+++ b/SimpleTowns/src/com/gmail/jameshealey1994/simpletowns/localisation/LocalisationEntry.java
@@ -466,7 +466,17 @@ public enum LocalisationEntry {
             "MsgChunkAlreadyClaimed",
             "%1$s - town name",
             "&cChunk already claimed by Town '%1$s'"),
-
+            
+   /**
+    * Message telling player that that they're the leader of multiple chunks next
+    * to the chunk they're claiming in, so they have to specify which town.
+    * %1$s - town name
+    */
+    MSG_MULTIPLE_TOWNS_NEARBY (
+    		"MsgMultipleTownsNearby",
+    		"%1$s - list of towns",
+    		"&cYou are the leader of multiple towns next to this chunk, please specify which one: %1$s"),
+    
     /**
      * Message to confirm to sender that a town has been created.
      * %1$s - town name

--- a/SimpleTowns/src/com/gmail/jameshealey1994/simpletowns/permissions/STPermission.java
+++ b/SimpleTowns/src/com/gmail/jameshealey1994/simpletowns/permissions/STPermission.java
@@ -1,7 +1,5 @@
 package com.gmail.jameshealey1994.simpletowns.permissions;
 
-import java.util.HashMap;
-
 import org.bukkit.Bukkit;
 import org.bukkit.permissions.Permission;
 
@@ -71,12 +69,7 @@ public enum STPermission {
      * Permission used by admins to override.
      */
     ADMIN ("simpletowns.admin");
-
-    /**
-     * A hashmap of already create permission objects
-     */
-	private HashMap<String, Permission> registeredPermissions = new HashMap<String, Permission>();
-	
+    
     /**
      * The name of the permission.
      */
@@ -114,6 +107,6 @@ public enum STPermission {
     	}
     	
     	// Send back an already created permission object
-        return this.registeredPermissions.get(Bukkit.getServer().getPluginManager().getPermission(this.getName()));
+        return (Bukkit.getServer().getPluginManager().getPermission(this.getName()));
     }
 }

--- a/SimpleTowns/src/com/gmail/jameshealey1994/simpletowns/permissions/STPermission.java
+++ b/SimpleTowns/src/com/gmail/jameshealey1994/simpletowns/permissions/STPermission.java
@@ -2,6 +2,7 @@ package com.gmail.jameshealey1994.simpletowns.permissions;
 
 import java.util.HashMap;
 
+import org.bukkit.Bukkit;
 import org.bukkit.permissions.Permission;
 
 /**
@@ -106,13 +107,13 @@ public enum STPermission {
      */
     public Permission getPermission() {
     	
-    	// Check if our HashMap doesn't contain the Permission object
-    	if(!this.registeredPermissions.containsKey(this.getName())) {
-    		// Add the permission object
-    		this.registeredPermissions.put(this.getName(), new Permission(this.getName()));
+    	// Check if the permission exists
+    	if(Bukkit.getServer().getPluginManager().getPermission(this.getName()) == null) {
+    		// Add the permission object to bukkit
+    		Bukkit.getServer().getPluginManager().addPermission(new Permission(this.getName()));
     	}
     	
     	// Send back an already created permission object
-        return this.registeredPermissions.get(this.getName());
+        return this.registeredPermissions.get(Bukkit.getServer().getPluginManager().getPermission(this.getName()));
     }
 }

--- a/SimpleTowns/src/com/gmail/jameshealey1994/simpletowns/permissions/STPermission.java
+++ b/SimpleTowns/src/com/gmail/jameshealey1994/simpletowns/permissions/STPermission.java
@@ -1,5 +1,7 @@
 package com.gmail.jameshealey1994.simpletowns.permissions;
 
+import java.util.HashMap;
+
 import org.bukkit.permissions.Permission;
 
 /**
@@ -8,7 +10,7 @@ import org.bukkit.permissions.Permission;
  * @author JamesHealey94 <jameshealey1994.gmail.com>
  */
 public enum STPermission {
-
+		
     /**
      * Permission for building in the wilderness above the Mine Y value.
      */
@@ -70,6 +72,11 @@ public enum STPermission {
     ADMIN ("simpletowns.admin");
 
     /**
+     * A hashmap of already create permission objects
+     */
+	private HashMap<String, Permission> registeredPermissions = new HashMap<String, Permission>();
+	
+    /**
      * The name of the permission.
      */
     private String name;
@@ -98,6 +105,14 @@ public enum STPermission {
      * @return  Permission of the enum
      */
     public Permission getPermission() {
-        return new Permission(this.getName());
+    	
+    	// Check if our HashMap doesn't contain the Permission object
+    	if(!this.registeredPermissions.containsKey(this.getName())) {
+    		// Add the permission object
+    		this.registeredPermissions.put(this.getName(), new Permission(this.getName()));
+    	}
+    	
+    	// Send back an already created permission object
+        return this.registeredPermissions.get(this.getName());
     }
 }

--- a/SimpleTowns/src/com/gmail/jameshealey1994/simpletowns/permissions/STPermission.java
+++ b/SimpleTowns/src/com/gmail/jameshealey1994/simpletowns/permissions/STPermission.java
@@ -1,5 +1,7 @@
 package com.gmail.jameshealey1994.simpletowns.permissions;
 
+import java.util.HashMap;
+
 import org.bukkit.Bukkit;
 import org.bukkit.permissions.Permission;
 
@@ -92,7 +94,9 @@ public enum STPermission {
     public String getName() {
         return name;
     }
-
+    
+    private HashMap<String, Permission> permissionMap = new HashMap<String, Permission>();
+    
     /**
      * Returns Permission of the enum.
      *
@@ -100,13 +104,28 @@ public enum STPermission {
      */
     public Permission getPermission() {
     	
+    	if(!permissionMap.containsKey(this.getName().toLowerCase())) {
+    		permissionMap.put(this.getName().toLowerCase(), new Permission(this.getName()));
+    	}
+    	
+    	return permissionMap.get(this.getName().toLowerCase());
+    	
+    	// I couldn't find a way to detect if a permission was already registered, so I'm using
+    	// our own HashMap to store this data.
+    	
+    	/*
     	// Check if the permission exists
     	if(Bukkit.getServer().getPluginManager().getPermission(this.getName()) == null) {
     		// Add the permission object to bukkit
-    		Bukkit.getServer().getPluginManager().addPermission(new Permission(this.getName()));
+    		try { 
+    			Bukkit.getServer().getPluginManager().addPermission();
+    		} catch(IllegalArgumentException e) {
+    			
+    		}
     	}
     	
     	// Send back an already created permission object
         return (Bukkit.getServer().getPluginManager().getPermission(this.getName()));
+        */
     }
 }


### PR DESCRIPTION
This adds the following cases:

If the player is a leader of 1 town, it claims for that town.

If the player is a leader of multiple towns, but there is only one next to the chunk they're claiming for, it claims for that town.

If the player is a leader of multiple towns next to the chunk they're claiming for, it lists these towns. 

If the player is a leader of multiple towns and none are next to the chunk they're claiming for, it results in the original message. 
